### PR TITLE
Fix CMAKE_INSTALL_LIBDIR var

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -20,7 +20,6 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.kde.*
-  - --env=LD_LIBRARY_PATH=/app/lib:/app/lib/nextcloud
   - --env=TMPDIR=/var/tmp
 
 cleanup:
@@ -40,8 +39,7 @@ modules:
   - name: qtkeychain
     buildsystem: cmake
     config-opts:
-      - -DCMAKE_INSTALL_LIBDIR=/app/lib
-      - -DLIB_INSTALL_DIR=/app/lib
+      - -DCMAKE_INSTALL_LIBDIR=lib
       - -DBUILD_TRANSLATIONS=NO
     sources:
       - type: archive
@@ -52,9 +50,8 @@ modules:
     buildsystem: cmake
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
       - -DNO_SHIBBOLETH=1
-      - -DCMAKE_INSTALL_LIBDIR=/app/lib
-      - -DLIB_INSTALL_DIR=/app/lib
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
     post-install:


### PR DESCRIPTION
Currently `CMAKE_INSTALL_LIBDIR` is set to the wrong value, which causes this:
```
-- Set runtime path of "/app/lib/libnextcloudsync.so.3.0.1" to "/app//app/lib/nextcloud"
```
Which is the reason why we needed to set `LD_LIBRARY_PATH` at runtime.

With this pr the  runtime path is set properly:
```
-- Set runtime path of "/app/lib/libnextcloudsync.so.3.0.1" to "/app/lib/nextcloud"
```
So there is no need to set `LD_LIBRARY_PATH` anymore.