### PR TITLE
Move beta to stable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,8 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: '5.12'
+runtime-version: '5.15'
 sdk: org.kde.Sdk
+
+base: io.qt.qtwebengine.BaseApp
+base-version: '5.15'
 
 command: nextcloud
 rename-icon: Nextcloud
@@ -24,23 +27,21 @@ finish-args:
 
 cleanup:
   - /share/icons/hicolor/1024x1024
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
 
 modules:
-  - name: libsecret
-    config-opts:
-      - --disable-static
-      - --disable-gtk-doc
-      - --disable-manpages
-    sources:
-      - type: archive
-        url: https://gitlab.gnome.org/GNOME/libsecret/-/archive/0.19.1/libsecret-0.19.1.tar.gz
-        sha256: 303c6e8cf3e12534e885b0682cd6130716c6834397b76d3829321b6d83b2389c
+  - shared-modules/libsecret/libsecret.json
 
   - name: qtkeychain
     buildsystem: cmake
     config-opts:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DBUILD_TRANSLATIONS=NO
+    cleanup:
+      - /include
+      - /mkspecs
+      - /lib/cmake
     sources:
       - type: archive
         url: https://github.com/frankosterfeld/qtkeychain/archive/v0.10.0.tar.gz
@@ -54,6 +55,8 @@ modules:
       - -DNO_SHIBBOLETH=1
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
+    cleanup:
+      - /include
     post-install:
       - install -Dm644 -t /app/share/metainfo com.nextcloud.desktopclient.nextcloud.metainfo.xml
     sources:

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -20,7 +20,6 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.kde.*
-  - --env=LD_LIBRARY_PATH=/app/lib:/app/lib/nextcloud
   - --env=TMPDIR=/var/tmp
 
 cleanup:
@@ -40,8 +39,7 @@ modules:
   - name: qtkeychain
     buildsystem: cmake
     config-opts:
-      - -DCMAKE_INSTALL_LIBDIR=/app/lib
-      - -DLIB_INSTALL_DIR=/app/lib
+      - -DCMAKE_INSTALL_LIBDIR=lib
       - -DBUILD_TRANSLATIONS=NO
     sources:
       - type: archive
@@ -52,9 +50,8 @@ modules:
     buildsystem: cmake
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
       - -DNO_SHIBBOLETH=1
-      - -DCMAKE_INSTALL_LIBDIR=/app/lib
-      - -DLIB_INSTALL_DIR=/app/lib
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
     post-install:


### PR DESCRIPTION
Mainly moves to org.kde.Platform version 5.15 (https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/pull/16)

And also fixes https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/issues/14

This causes users on newer flatpak versions to have to re-login, since the new libsecret uses the new flaptak secret store/portal.
Closes https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/issues/11