### PR TITLE
Use Concise Display Name

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.nextcloud.desktopclient.nextcloud</id>
-  <name>Nextcloud desktop sync client</name>
+  <name>Nextcloud Desktop</name>
   <project_license>GPL-2.0+</project_license>
   <summary>Nextcloud desktop synchronization client</summary>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
The norm on Flathub seems to be for the `<name>` field to be title-case and concise, and the existing longer string in this field is redundant with the one in the `<summary>` field. Admittedly, the only places the `<name>` field shows up in the user interface is the Flathub website and GNOME Software, but it's nice to be tidy.

I created a pull request with a similar change to the `.desktop` file over at the main repository: https://github.com/nextcloud/desktop/pull/3048