### PR TITLE
Update description image URL

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -16,7 +16,7 @@ to the client, you can work with your files even when you are not online!</p>
   <screenshots>
     <screenshot type="default">
       <caption>The options dialog</caption>
-      <image>https://nextcloud.com/wp-content/themes/next/assets/img/clients/desktop/linux.png?x16328</image>
+      <image>https://nextcloud.com/wp-content/uploads/2022/04/linux.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>


### PR DESCRIPTION
The current image used in the description returns 404. This new URL is the same image but with a valid link.