### PR TITLE
Update runtime to 22.08

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-21.08
+base-version: 5.15-22.08
 
 command: nextcloud
 rename-icon: Nextcloud


### PR DESCRIPTION
Update KDE runtime to version 22.08

Closes: https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/issues/94

This is just a maintenance change, just like previous update: https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/pull/69