### PR TITLE
restore talking to kde wallet, fix #125

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -22,6 +22,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.kde.kwalletd5
   - --env=TMPDIR=/var/tmp
 
 cleanup:


### PR DESCRIPTION
The app lost ability to use KDE wallet, possibly after removing `- --own-name=org.kde.*` in ([#112](https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/pull/112)). This change might restore it.

Edit: this fixes #125 