### PR TITLE
fix(theme): Disable broken gnome theme

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -23,6 +23,7 @@ finish-args:
   - --own-name=com.nextcloudgmbh.Nextcloud
   - --talk-name=org.kde.kwalletd5
   - --env=TMPDIR=/var/tmp
+  - --env=QT_QPA_PLATFORMTHEME=kde
 
 cleanup:
   - /share/icons/hicolor/1024x1024


### PR DESCRIPTION
As QGnomePlatform is no longer maintained, the theme should be set to KDE by default. This fixes broken rendering on newer gnome desktops. fixes https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/issues/115