### PR TITLE
bump kde runtime to 23.08

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: 5.15-22.08
+runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-22.08
+base-version: 5.15-23.08
 
 command: nextcloud
 


### PR DESCRIPTION
While trying to fix #115 in #130 I also bumped the KDE runtime to 23.10

I've separated the two PRs in case you only want to use the fix and not upgrade the runtime yet for whatever reason