### PR TITLE
Revert "Merge pull request #130 from p-fruck/fix/remove-gnome-theming"

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -23,7 +23,6 @@ finish-args:
   - --own-name=com.nextcloudgmbh.Nextcloud
   - --talk-name=org.kde.kwalletd5
   - --env=TMPDIR=/var/tmp
-  - --env=QT_QPA_PLATFORMTHEME=kde
 
 cleanup:
   - /share/icons/hicolor/1024x1024


### PR DESCRIPTION
This reverts commit daf49adeff317e44d997941351a4f2a75dbb5562, reversing changes made to 646b3d378a7780bb5cfc52ef259cda9777d4ff6a.

The previous merge request "fixed" #115 by "removing GNOME theming". It did this in the wrong way though, by forcing other platform-specific theming.

Unfortunately, despite its deprecation, Flatpak still installs GNOME theming for Qt apps when a Qt app is installed. Once I figure out where to propose that this be changed, I will do.

However, in the meantime, forcing other platform-specific theming is not the solution, if the GNOME theming breaks Nextcloud.

The current solution must be implemented by Flatpak, and, until then, can be achieved by uninstall the GNOME theming if it's already installed, and preventing it from be installed in the future:
```
flatpak uninstall org.kde.KStyle.Adwaita org.kde.PlatformTheme.QGnomePlatform org.kde.WaylandDecoration.QAdwaitaDecorations org.kde.WaylandDecoration.QGnomePlatform-decoration

sudo flatpak mask org.kde.KStyle.Adwaita org.kde.PlatformTheme.QGnomePlatform org.kde.WaylandDecoration.QAdwaitaDecorations org.kde.WaylandDecoration.QGnomePlatform-decoration
```