### PR TITLE
Build v3.14.0 using QT 6

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,7 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        commit: f44eb5b8d4c53110f801e7c58b4100be8006df12
+        tag: v3.14.0
+        commit: d8fcb9273729c0e70f99d6f42ed7185c2bb69779
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: '6.7'
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-23.08
+base-version: '6.7'
 
 command: nextcloud
 
@@ -38,14 +38,15 @@ modules:
     config-opts:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DBUILD_TRANSLATIONS=NO
+      - -DBUILD_WITH_QT6=1
     cleanup:
       - /include
       - /mkspecs
       - /lib/cmake
     sources:
       - type: archive
-        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.2.tar.gz
-        sha256: cf2e972b783ba66334a79a30f6b3a1ea794a1dc574d6c3bebae5ffd2f0399571
+        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.3.tar.gz
+        sha256: a22c708f351431d8736a0ac5c562414f2b7bb919a6292cbca1ff7ac0849cb0a7
         x-checker-data:
           type: anitya
           url-template: https://github.com/frankosterfeld/qtkeychain/archive/$version.tar.gz
@@ -83,6 +84,7 @@ modules:
       - -DBUILD_UPDATER=OFF
       - -DPLUGIN_INSTALL_DIR=/app/lib/plugins
       - -DPLUGINDIR=/app/lib/plugins
+      - -DQT_MAJOR_VERSION=6
     cleanup:
       - /include
     post-install:
@@ -90,8 +92,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.12.3
-        commit: e4ad64aa1950ed482485be416d50296bc2130e20
+        commit: f44eb5b8d4c53110f801e7c58b4100be8006df12
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/dbus-service-path.patch
+++ b/dbus-service-path.patch
@@ -4,8 +4,13 @@ index 2e7349ef7..f7a161c05 100644
 +++ b/shell_integration/libcloudproviders/CMakeLists.txt
 @@ -1,5 +1,5 @@
  macro(dbus_add_activation_service _sources)
+ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28.0") 
+-    pkg_get_variable(_install_dir dbus-1 session_bus_services_dir DEFINE_VARIABLES datadir=${CMAKE_INSTALL_DATADIR})
++    set(_install_dir "${CMAKE_INSTALL_PREFIX}/share/dbus-1/services")
+ else()
 -    pkg_get_variable(_install_dir dbus-1 session_bus_services_dir)
 +    set(_install_dir "${CMAKE_INSTALL_PREFIX}/share/dbus-1/services")
+ endif()
      foreach (_i ${_sources})
          get_filename_component(_service_file ${_i} ABSOLUTE)
          string(REGEX REPLACE "\\.service.*$" ".service" _output_file ${_i})

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
Nextcloud client is transitioning to QT6 as QT5 is end of life. My build instructions are based on the changes from https://github.com/nextcloud/desktop/pull/4584 which does not have a stable nextcloud client release yet, so I am currently building from main branch.

The nextcloud client can be built and runs properly. Migrating to QT6 fixes the issues many people (including me) experienced with the deprecated/EOL QT5 runtime.

![ncdesktop](https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/assets/30511472/f1dad08c-3329-4b12-aefe-cc5a042375ea)

To the maintainers: The issues around  missing elements have not been fixed for quite some time. I cannot afford dedicating large parts of my freetime to this project, but if you are interested in me supporting you maintaining the client, consider reaching out to me, as I also provided a PR for the last visual flatpak runtime issues: https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/pull/130