### PR TITLE
Enable Nautilus integration and sync status icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.flatpak-builder
 /build-dir
+/repo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Flatpak Manifest for Nextcloud Desktop
+
+## Build and run
+Clone this repo (including submodules):
+```
+git clone --recurse-submodules https://github.com/flathub/com.nextcloud.desktopclient.nextcloud.git
+```
+And follow the [build & run instructions in the Flathub docs](https://docs.flathub.org/docs/for-app-authors/submission#build-and-install).
+
+## Flatpak specific tweaks
+### Enable GNOME Files / Nautilus Integration
+Make sure you:
+- Installed the [Nexcloud Desktop from Flathub](https://flathub.org/apps/details/com.nextcloud.desktopclient.nextcloud).
+- Installed [GNOME Files / Nautilus](https://gitlab.gnome.org/GNOME/nautilus) and [nautilus-python](https://gitlab.gnome.org/GNOME/nautilus-python) from your distros package manager (e.g. `sudo apt install nautilus python3-nautilus` for Ubuntu 24.04).
+Create a symlink to [Nextclouds Nautilus script](https://github.com/nextcloud/desktop/blob/a595d5bcb6f13f4ea4080b694682a5ae43e2f769/shell_integration/nautilus/syncstate.py) (which comes with the Flatpak):
+```
+nc=$(readlink -f "$(flatpak info -l com.nextcloud.desktopclient.nextcloud)/../../../")
+syncstate='/nautilus-python/extensions/syncstate-Nextcloud.py'  # for Nautilus
+#syncstate='/caja-python/extensions/syncstate-Nextcloud.py'  # for Caja
+#syncstate='/nemo-python/extensions/syncstate-Nextcloud.py'  # for Nemo
+nc_syncstate_path="${nc}/current/active/files/share${syncstate}"
+user_syncstate_path="${XDG_DATA_HOME:-${HOME}/.local/share}${syncstate}"
+
+mkdir -v -p "$(dirname ${user_syncstate_path})"
+ln -v -s "${nc_syncstate_path}" "${user_syncstate_path}"
+```
+After you restart Nautilus, the script loads and enables the sync state icons as well as a right-click menu for your Nextcloud files in Nautilus.
+
+When using the respective `syncstate=` line it might also work for Caja (MATEs file manager) or Nemo (Cinnamons file manager in Linux Mint). But this was only tested with Nautilus on Ubuntu 24.04 so your millage may vary.

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -91,7 +91,6 @@ modules:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DNO_SHIBBOLETH=1
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
-      - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
       - -DBUILD_UPDATER=OFF
       - -DPLUGIN_INSTALL_DIR=/app/lib/plugins
       - -DPLUGINDIR=/app/lib/plugins
@@ -115,5 +114,7 @@ modules:
         path: dbus-service-path.patch
       - type: patch
         path: icon-name.patch
+      - type: patch
+        path: sync-icons.patch
       - type: file
         path: com.nextcloud.desktopclient.nextcloud.metainfo.xml

--- a/sync-icons.patch
+++ b/sync-icons.patch
@@ -1,0 +1,45 @@
+diff --git a/shell_integration/icons/CMakeLists.txt b/shell_integration/icons/CMakeLists.txt
+index c77feca..18b21b7 100644
+--- a/shell_integration/icons/CMakeLists.txt
++++ b/shell_integration/icons/CMakeLists.txt
+@@ -7,7 +7,7 @@ if( UNIX AND NOT APPLE )
+ 	FOREACH( file ${files} )
+ 	    # the GLOB returns a absolute path. Make it relative by replacing the current src dir by nothing
+ 	    STRING(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/${size}/" "" shortFile ${file})
+-	    STRING(REPLACE "oC" ${APPLICATION_SHORTNAME} brandedName ${shortFile})
++	    STRING(REPLACE "oC" "com.nextcloud.desktopclient.nextcloud-${APPLICATION_SHORTNAME}" brandedName ${shortFile})
+ 	    install(FILES ${file} DESTINATION ${ICON_DIR}/${size}/apps RENAME ${brandedName})
+ 	ENDFOREACH(file)
+     ENDFOREACH(size)
+diff --git a/shell_integration/nautilus/syncstate.py b/shell_integration/nautilus/syncstate.py
+index eb5e0a0..941c4b0 100644
+--- a/shell_integration/nautilus/syncstate.py
++++ b/shell_integration/nautilus/syncstate.py
+@@ -428,16 +428,17 @@ class SyncStateExtension_ownCloud(GObject.GObject, Nautilus.InfoProvider):
+             self.invalidate_items_underneath(args[0])
+ 
+     def set_emblem(self, item, state):
+-        Emblems = { 'OK'        : appname +'_ok',
+-                    'SYNC'      : appname +'_sync',
+-                    'NEW'       : appname +'_sync',
+-                    'IGNORE'    : appname +'_warn',
+-                    'ERROR'     : appname +'_error',
+-                    'OK+SWM'    : appname +'_ok_shared',
+-                    'SYNC+SWM'  : appname +'_sync_shared',
+-                    'NEW+SWM'   : appname +'_sync_shared',
+-                    'IGNORE+SWM': appname +'_warn_shared',
+-                    'ERROR+SWM' : appname +'_error_shared',
++        flatpak_id = 'com.nextcloud.desktopclient.nextcloud-'
++        Emblems = { 'OK'        : flatpak_id + appname +'_ok',
++                    'SYNC'      : flatpak_id + appname +'_sync',
++                    'NEW'       : flatpak_id + appname +'_sync',
++                    'IGNORE'    : flatpak_id + appname +'_warn',
++                    'ERROR'     : flatpak_id + appname +'_error',
++                    'OK+SWM'    : flatpak_id + appname +'_ok_shared',
++                    'SYNC+SWM'  : flatpak_id + appname +'_sync_shared',
++                    'NEW+SWM'   : flatpak_id + appname +'_sync_shared',
++                    'IGNORE+SWM': flatpak_id + appname +'_warn_shared',
++                    'ERROR+SWM' : flatpak_id + appname +'_error_shared',
+                     'NOP'       : ''
+                   }
+ 


### PR DESCRIPTION
The shell integration only works if you create a proper symlink which is documented in the new README.md.

Also adds /repo to .gitignore because it is created if you follow: https://docs.flathub.org/docs/for-app-authors/submission#build-and-install

---

Hi,

I am more or less working with Flatpak for first time here so maybe you have some tips to get a better solution than manually creating a symlink to the `syncstate.py` scripts (see README.md)?
I think ideally there's a config / way to build the scripts into the Flatpak export folders (e.g. `$HOME/.local/share/flatpak/exports/share` and `/var/lib/flatpak/exports/share`) but IDK how to configure this.
Does maybe someone here know more about this? Or is it just prefixing them with the Flatpak ID (similar to [the sync status icons](https://docs.flatpak.org/en/latest/conventions.html#application-icons))?
I anyway wanted to share this since it should work rather well (I think it might even survive app updates).

I basically did a slightly nicer version than: https://gist.github.com/p-fruck/6ec354da8fb348c19cca013c6c64df76

BR
scde