### PR TITLE
Drop libsecret module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -35,7 +35,6 @@ cleanup-commands:
   - /app/cleanup-BaseApp.sh
 
 modules:
-  - shared-modules/libsecret/libsecret.json
 
   - name: qtkeychain
     buildsystem: cmake-ninja


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides libsecret; therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/issues/223