### PR TITLE
Implement autostart

### DIFF
--- a/autostart.patch
+++ b/autostart.patch
@@ -1,0 +1,24 @@
+diff --git a/src/common/utility_unix.cpp b/src/common/utility_unix.cpp
+index fc7d560..73caa36 100644
+--- a/src/common/utility_unix.cpp
++++ b/src/common/utility_unix.cpp
+@@ -100,14 +100,16 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString &guiName,
+         // When running inside an AppImage, we need to set the path to the
+         // AppImage instead of the path to the executable
+         const QString appImagePath = qEnvironmentVariable("APPIMAGE");
++        const QString flatpakId = qEnvironmentVariable("FLATPAK_ID");
+         const bool runningInsideAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
+-        const QString executablePath = runningInsideAppImage ? appImagePath : QCoreApplication::applicationFilePath();
++        const bool runningInsideFlatpak = !flatpakId.isNull();
++        const QString executablePath = runningInsideAppImage ? QLatin1String("\"%1\"").arg(appImagePath) : runningInsideFlatpak ? QLatin1String("flatpak run %1").arg(flatpakId) : QLatin1String("\"%1\"").arg(QCoreApplication::applicationFilePath());
+ 
+         QTextStream ts(&iniFile);
+         ts << QLatin1String("[Desktop Entry]\n")
+            << QLatin1String("Name=") << guiName << QLatin1Char('\n')
+            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer\n")
+-           << QLatin1String("Exec=\"") << executablePath << "\" --background\n"
++           << QLatin1String("Exec=") << executablePath << " --background\n"
+            << QLatin1String("Terminal=") << "false\n"
+            << QLatin1String("Icon=") << APPLICATION_ICON_NAME << QLatin1Char('\n')
+            << QLatin1String("Categories=") << QLatin1String("Network\n")
+

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -17,6 +17,7 @@ finish-args:
   - --share=ipc
   - --filesystem=host:rw
   - --filesystem=xdg-run/Nextcloud:create
+  - --filesystem=xdg-config/autostart
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
@@ -118,5 +119,7 @@ modules:
         path: dbus-service-path.patch
       - type: patch
         path: icon-name.patch
+      - type: patch
+        path: autostart.patch
       - type: file
         path: com.nextcloud.desktopclient.nextcloud.metainfo.xml


### PR DESCRIPTION
Fixes #18

Patches `Utility::setLaunchOnStartup` so that it supports flatpaks and adds `xdg-config/autostart` to filesystem exposure.

Many (including myself) would argue exposing `xdg-config/autostart` is bad practice (should use Background portal instead) but it does undeniably fix the issue without rewriting this whole function to use portals (which imo is a lot for a patch). If this is a deal-breaker don't merge I won't be mad :smiley: 