### PR TITLE
chore: remove unused Shibboleth config option

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,7 +92,6 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib
-      - -DNO_SHIBBOLETH=1
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
       - -DBUILD_UPDATER=OFF


### PR DESCRIPTION
v3.2.0 (released in 2021) removed the support for Shibboleth credentials.