### PR TITLE
Sync `beta` branch with `master`, add autocheck for prereleases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,6 +27,9 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.16.3" date="2025-04-16">
+      <description></description>
+    </release>
     <release version="3.16.2" date="2025-03-19">
       <description></description>
     </release>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,6 +27,9 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.14.0" date="2024-09-14">
+      <description></description>
+    </release>
     <release version="3.12.3" date="2024-03-28"/>
     <release version="3.12.2" date="2024-03-20"/>
     <release version="3.12.1" date="2024-03-07"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="4.0.1" date="2025-10-27">
+    <release version="4.0.2" date="2025-11-25">
       <description></description>
+    </release>
+    <release version="4.0.1" date="2025-10-27">
+      <description/>
     </release>
     <release version="3.17.3" date="2025-10-10">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.16.6" date="2025-06-19">
+    <release version="3.17.0" date="2025-08-13">
       <description></description>
+    </release>
+    <release version="3.16.6" date="2025-06-19">
+      <description/>
     </release>
     <release version="3.16.5" date="2025-06-03">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.16.5" date="2025-06-03">
+    <release version="3.16.6" date="2025-06-19">
       <description></description>
+    </release>
+    <release version="3.16.5" date="2025-06-03">
+      <description/>
     </release>
     <release version="3.16.4" date="2025-04-28">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.14.1" date="2024-09-27">
+    <release version="3.14.2" date="2024-10-21">
       <description></description>
+    </release>
+    <release version="3.14.1" date="2024-09-27">
+      <description/>
     </release>
     <release version="3.14.0" date="2024-09-14">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -22,6 +22,9 @@ to the client, you can work with your files even when you are not online!</p>
       <image>https://nextcloud.com/wp-content/uploads/2022/04/linux.png</image>
     </screenshot>
   </screenshots>
+  <branding>
+    <color type="primary">#0082c9</color>
+  </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
     <release version="3.12.1" date="2024-03-07"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -24,6 +24,7 @@ to the client, you can work with your files even when you are not online!</p>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.12.1" date="2024-03-07"/>
     <release version="3.12.0" date="2024-02-14"/>
     <release version="3.11.1" date="2024-01-30"/>
     <release version="3.11.0" date="2023-12-12"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.17.1" date="2025-08-19">
+    <release version="3.17.2" date="2025-09-16">
       <description></description>
+    </release>
+    <release version="3.17.1" date="2025-08-19">
+      <description/>
     </release>
     <release version="3.17.0" date="2025-08-13">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.17.2" date="2025-09-16">
+    <release version="3.17.3" date="2025-10-10">
       <description></description>
+    </release>
+    <release version="3.17.2" date="2025-09-16">
+      <description/>
     </release>
     <release version="3.17.1" date="2025-08-19">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -76,4 +76,5 @@ to the client, you can work with your files even when you are not online!</p>
     <release date="2019-07-22" version="2.5.3"/>
   </releases>
   <content_rating type="oars-1.1"/>
+  <developer_name>Nextcloud GmbH</developer_name>
 </component>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,6 +27,9 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.16.1" date="2025-03-13">
+      <description></description>
+    </release>
     <release version="3.16.0" date="2025-03-10">
       <description></description>
     </release>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.14.2" date="2024-10-21">
+    <release version="3.14.3" date="2024-11-04">
       <description></description>
+    </release>
+    <release version="3.14.2" date="2024-10-21">
+      <description/>
     </release>
     <release version="3.14.1" date="2024-09-27">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.16.4" date="2025-04-28">
+    <release version="3.16.5" date="2025-06-03">
       <description></description>
+    </release>
+    <release version="3.16.4" date="2025-04-28">
+      <description/>
     </release>
     <release version="3.16.3" date="2025-04-16">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -21,6 +21,7 @@ to the client, you can work with your files even when you are not online!</p>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.11.0" date="2023-12-12"/>
     <release version="3.10.2" date="2023-12-08"/>
     <release version="3.10.1" date="2023-10-26"/>
     <release version="3.10.0" date="2023-09-16"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,6 +27,9 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.16.2" date="2025-03-19">
+      <description></description>
+    </release>
     <release version="3.16.1" date="2025-03-13">
       <description></description>
     </release>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -24,6 +24,7 @@ to the client, you can work with your files even when you are not online!</p>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.12.3" date="2024-03-28"/>
     <release version="3.12.2" date="2024-03-20"/>
     <release version="3.12.1" date="2024-03-07"/>
     <release version="3.12.0" date="2024-02-14"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -5,7 +5,7 @@
   <project_license>GPL-2.0+</project_license>
   <summary>Nextcloud desktop synchronization client</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <developer id="com.Nextcloud">
+  <developer id="com.nextcloud">
     <name>Nextcloud GmbH</name>
   </developer>
   <description>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -9,7 +9,7 @@
     <name>Nextcloud GmbH</name>
   </developer>
   <description>
-    <p>The Nextcloud desktop client keeps photos and documents always up to date, enabling you to work like you always did.<br>
+    <p>The Nextcloud desktop client keeps photos and documents always up to date, enabling you to work like you always did.
 Any file you add, modify or delete in the synced folders on your desktop or laptop will show up, change or disappear on the server and all other connected devices.</p>
   </description>
   <launchable type="desktop-id">com.nextcloud.desktopclient.nextcloud.desktop</launchable>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -20,9 +20,13 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
     </screenshot>
   </screenshots>
   <branding>
-    <color type="primary">#0082c9</color>
+    <color type="primary" scheme_preference="light">#0082c9</color>
+    <color type="primary" scheme_preference="dark">#0082c9</color>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
+  <url type="bugtracker">https://github.com/nextcloud/desktop/issues</url>
+  <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
+  <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
     <release version="3.16.4" date="2025-04-28">
       <description></description>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.15.0" date="2024-11-25">
+    <release version="3.15.1" date="2024-12-13">
       <description></description>
+    </release>
+    <release version="3.15.0" date="2024-11-25">
+      <description/>
     </release>
     <release version="3.14.3" date="2024-11-04">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.15.1" date="2024-12-13">
+    <release version="3.15.2" date="2024-12-16">
       <description></description>
+    </release>
+    <release version="3.15.1" date="2024-12-13">
+      <description/>
     </release>
     <release version="3.15.0" date="2024-11-25">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,17 +27,20 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.16.3" date="2025-04-16">
+    <release version="3.16.4" date="2025-04-28">
       <description></description>
+    </release>
+    <release version="3.16.3" date="2025-04-16">
+      <description/>
     </release>
     <release version="3.16.2" date="2025-03-19">
-      <description></description>
+      <description/>
     </release>
     <release version="3.16.1" date="2025-03-13">
-      <description></description>
+      <description/>
     </release>
     <release version="3.16.0" date="2025-03-10">
-      <description></description>
+      <description/>
     </release>
     <release version="3.15.3" date="2025-01-07">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="4.0.3" date="2025-12-03">
+    <release version="4.0.4" date="2025-12-15">
       <description></description>
+    </release>
+    <release version="4.0.3" date="2025-12-03">
+      <description/>
     </release>
     <release version="4.0.2" date="2025-11-25">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -81,5 +81,4 @@ to the client, you can work with your files even when you are not online!</p>
     <release date="2019-07-22" version="2.5.3"/>
   </releases>
   <content_rating type="oars-1.1"/>
-  <developer_name>Nextcloud GmbH</developer_name>
 </component>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.14.3" date="2024-11-04">
+    <release version="3.15.0" date="2024-11-25">
       <description></description>
+    </release>
+    <release version="3.14.3" date="2024-11-04">
+      <description/>
     </release>
     <release version="3.14.2" date="2024-10-21">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.nextcloud.desktopclient.nextcloud</id>
-  <name>Nextcloud Desktop</name>
+  <name>Nextcloud Desktop Client</name>
   <project_license>GPL-2.0+</project_license>
-  <summary>Nextcloud desktop synchronization client</summary>
+  <summary>Sync and collaborate on your desktop or laptop</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <developer id="com.nextcloud">
     <name>Nextcloud GmbH</name>
   </developer>
   <description>
-    <p>The Nextcloud desktop client allows you to keep one or more folders full of
-your photos, videos and documents synchronized with your server. Any file you
-add, modify or delete in the synced folders on your desktop or laptop will show
-up, change or disappear on the server and all other connected devices. Thanks
-to the client, you can work with your files even when you are not online!</p>
+    <p>The Nextcloud desktop client keeps photos and documents always up to date, enabling you to work like you always did.<br>
+Any file you add, modify or delete in the synced folders on your desktop or laptop will show up, change or disappear on the server and all other connected devices.</p>
   </description>
   <launchable type="desktop-id">com.nextcloud.desktopclient.nextcloud.desktop</launchable>
   <screenshots>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="4.0.2" date="2025-11-25">
+    <release version="4.0.3" date="2025-12-03">
       <description></description>
+    </release>
+    <release version="4.0.2" date="2025-11-25">
+      <description/>
     </release>
     <release version="4.0.1" date="2025-10-27">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.17.3" date="2025-10-10">
+    <release version="4.0.1" date="2025-10-27">
       <description></description>
+    </release>
+    <release version="3.17.3" date="2025-10-10">
+      <description/>
     </release>
     <release version="3.17.2" date="2025-09-16">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -24,6 +24,7 @@ to the client, you can work with your files even when you are not online!</p>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.12.2" date="2024-03-20"/>
     <release version="3.12.1" date="2024-03-07"/>
     <release version="3.12.0" date="2024-02-14"/>
     <release version="3.11.1" date="2024-01-30"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -21,6 +21,7 @@ to the client, you can work with your files even when you are not online!</p>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.10.2" date="2023-12-08"/>
     <release version="3.10.1" date="2023-10-26"/>
     <release version="3.10.0" date="2023-09-16"/>
     <release version="3.9.4" date="2023-09-06"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="3.17.0" date="2025-08-13">
+    <release version="3.17.1" date="2025-08-19">
       <description></description>
+    </release>
+    <release version="3.17.0" date="2025-08-13">
+      <description/>
     </release>
     <release version="3.16.6" date="2025-06-19">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -5,6 +5,9 @@
   <project_license>GPL-2.0+</project_license>
   <summary>Nextcloud desktop synchronization client</summary>
   <metadata_license>CC0-1.0</metadata_license>
+  <developer id="com.Nextcloud">
+    <name>Nextcloud GmbH</name>
+  </developer>
   <description>
     <p>The Nextcloud desktop client allows you to keep one or more folders full of
 your photos, videos and documents synchronized with your server. Any file you
@@ -21,6 +24,8 @@ to the client, you can work with your files even when you are not online!</p>
   </screenshots>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
+    <release version="3.12.0" date="2024-02-14"/>
+    <release version="3.11.1" date="2024-01-30"/>
     <release version="3.11.0" date="2023-12-12"/>
     <release version="3.10.2" date="2023-12-08"/>
     <release version="3.10.1" date="2023-10-26"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.15.2" date="2024-12-16">
+    <release version="3.15.3" date="2025-01-07">
       <description></description>
+    </release>
+    <release version="3.15.2" date="2024-12-16">
+      <description/>
     </release>
     <release version="3.15.1" date="2024-12-13">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.15.3" date="2025-01-07">
+    <release version="3.16.0" date="2025-03-10">
       <description></description>
+    </release>
+    <release version="3.15.3" date="2025-01-07">
+      <description/>
     </release>
     <release version="3.15.2" date="2024-12-16">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -27,8 +27,11 @@ to the client, you can work with your files even when you are not online!</p>
   </branding>
   <url type="homepage">https://nextcloud.com</url>
   <releases>
-    <release version="3.14.0" date="2024-09-14">
+    <release version="3.14.1" date="2024-09-27">
       <description></description>
+    </release>
+    <release version="3.14.0" date="2024-09-14">
+      <description/>
     </release>
     <release version="3.12.3" date="2024-03-28"/>
     <release version="3.12.2" date="2024-03-20"/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="4.0.5" date="2026-01-20">
+    <release version="4.0.6" date="2026-01-22">
       <description></description>
+    </release>
+    <release version="4.0.5" date="2026-01-20">
+      <description/>
     </release>
     <release version="4.0.4" date="2025-12-15">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="4.0.4" date="2025-12-15">
+    <release version="4.0.5" date="2026-01-20">
       <description></description>
+    </release>
+    <release version="4.0.4" date="2025-12-15">
+      <description/>
     </release>
     <release version="4.0.3" date="2025-12-03">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="4.0.6" date="2026-01-22">
+    <release version="33.0.0-rc1" date="2026-02-18">
       <description></description>
+    </release>
+    <release version="4.0.6" date="2026-01-22">
+      <description/>
     </release>
     <release version="4.0.5" date="2026-01-20">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -35,7 +35,6 @@ cleanup-commands:
   - /app/cleanup-BaseApp.sh
 
 modules:
-  - shared-modules/libsecret/libsecret.json
 
   - name: qtkeychain
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -75,12 +75,16 @@ modules:
 
   - name: libp11
     buildsystem: autotools
+    config-opts:
+      - --prefix=/
     cleanup:
       - /include
     sources:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
         sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
+    make-install-args:
+      - DESTDIR=${FLATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -83,7 +83,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
-        sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60ATPAK_DEST}
+        sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -43,8 +43,8 @@ modules:
       - /lib/cmake
     sources:
       - type: archive
-        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.1.tar.gz
-        sha256: afb2d120722141aca85f8144c4ef017bd74977ed45b80e5d9e9614015dadd60c
+        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.2.tar.gz
+        sha256: cf2e972b783ba66334a79a30f6b3a1ea794a1dc574d6c3bebae5ffd2f0399571
         x-checker-data:
           type: anitya
           url-template: https://github.com/frankosterfeld/qtkeychain/archive/$version.tar.gz

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,7 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        commit: f44eb5b8d4c53110f801e7c58b4100be8006df12
+        tag: v3.14.0
+        commit: d8fcb9273729c0e70f99d6f42ed7185c2bb69779
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.17.3
-        commit: 392da9a259781ab229d0b101464516c40c0e1ee6
+        tag: v4.0.1
+        commit: e81c242e131f207f0c18081004453a01af5bd51e
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/World/libcloudproviders.git
-        tag: 0.3.4
-        commit: 141fb072cc5080a8c547b8a536a45c0f9cf65691
+        tag: 0.3.6
+        commit: 9702091d5f77c2d1dfe1f8ca254c0910738da359
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -26,6 +26,10 @@ finish-args:
   - --env=TMPDIR=/var/tmp
 
 cleanup:
+  - /lib/*.a
+  - /lib/*.la
+  - /lib/x86_64-linux-gnu/pkgconfig
+  - /share/doc
   - /share/icons/hicolor/1024x1024
 cleanup-commands:
   - /app/cleanup-BaseApp.sh

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: 5.15-22.08
+runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-22.08
+base-version: 5.15-23.08
 
 command: nextcloud
 

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.5
-        commit: 930e6e637c8fda12d775a4c9ad286e5e34e78470
+        tag: v3.16.6
+        commit: 957b27497fbe7ca14c26a45e6967a097b96a0add
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: '6.7'
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-23.08
+base-version: '6.7'
 
 command: nextcloud
 
@@ -38,14 +38,15 @@ modules:
     config-opts:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DBUILD_TRANSLATIONS=NO
+      - -DBUILD_WITH_QT6=1
     cleanup:
       - /include
       - /mkspecs
       - /lib/cmake
     sources:
       - type: archive
-        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.2.tar.gz
-        sha256: cf2e972b783ba66334a79a30f6b3a1ea794a1dc574d6c3bebae5ffd2f0399571
+        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.3.tar.gz
+        sha256: a22c708f351431d8736a0ac5c562414f2b7bb919a6292cbca1ff7ac0849cb0a7
         x-checker-data:
           type: anitya
           url-template: https://github.com/frankosterfeld/qtkeychain/archive/$version.tar.gz
@@ -83,6 +84,7 @@ modules:
       - -DBUILD_UPDATER=OFF
       - -DPLUGIN_INSTALL_DIR=/app/lib/plugins
       - -DPLUGINDIR=/app/lib/plugins
+      - -DQT_MAJOR_VERSION=6
     cleanup:
       - /include
     post-install:
@@ -90,8 +92,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.12.3
-        commit: e4ad64aa1950ed482485be416d50296bc2130e20
+        commit: f44eb5b8d4c53110f801e7c58b4100be8006df12
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -75,12 +75,15 @@ modules:
 
   - name: libp11
     buildsystem: autotools
+    config-opts:
+      - --with-enginesdir=${FLATPAK_DEST}/lib/engines-3/
+      - --with-modulesdir=${FLATPAK_DEST}/lib/ossl-modules/
     cleanup:
       - /include
     sources:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
-        sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
+        sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60ATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.14.0
-        commit: d8fcb9273729c0e70f99d6f42ed7185c2bb69779
+        tag: v3.14.1
+        commit: 8b92fc33a289bf4fc7bc7cdd68d25a9ed1ae1782
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -81,8 +81,6 @@ modules:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
         sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
-    make-install-args:
-      - DESTDIR=${FLATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -81,8 +81,8 @@ modules:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
         sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
-    make-install-args:
-      - DESTDIR=${FLATPAK_DEST}
+    config-opts:
+      - --prefix=${FLATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -79,8 +79,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.12/libp11-0.4.12.tar.gz
-        sha256: 1e1a2533b3fcc45fde4da64c9c00261b1047f14c3f911377ebd1b147b3321cfd
+        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
+        sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
     make-install-args:
       - DESTDIR=${FLATPAK_DEST}
 

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -86,8 +86,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.11.0
-        commit: f91ae00cfa5113e0991d7c476460c8f55a80990f
+        tag: v3.12.0
+        commit: 1c1e752c4d2a49b3f0c34eba35f88157d5e55a20
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -23,7 +23,6 @@ finish-args:
   - --own-name=com.nextcloudgmbh.Nextcloud
   - --talk-name=org.kde.kwalletd5
   - --env=TMPDIR=/var/tmp
-  - --env=QT_QPA_PLATFORMTHEME=kde
 
 cleanup:
   - /share/icons/hicolor/1024x1024

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -81,6 +81,8 @@ modules:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
         sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
+    make-install-args:
+      - DESTDIR=${FLATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -89,8 +89,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.12.2
-        commit: b846740b0207f9f0934402e19c6a1f3921cf6d11
+        tag: v3.12.3
+        commit: e4ad64aa1950ed482485be416d50296bc2130e20
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.4
-        commit: 0febbee77be35f9a17f591b22767e1500192d14f
+        tag: v3.16.5
+        commit: 930e6e637c8fda12d775a4c9ad286e5e34e78470
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.15.3
-        commit: a595d5bcb6f13f4ea4080b694682a5ae43e2f769
+        tag: v3.16.0
+        commit: cbe48da7dc88d84606fb7159534350d199162f94
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -87,9 +87,6 @@ modules:
 
   - name: nextcloud-client
     buildsystem: cmake-ninja
-    build-options:
-      env:
-        PKG_CONFIG_PATH: /app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.8'
+base-version: '6.9'
 
 command: nextcloud
 
@@ -74,7 +74,6 @@ modules:
         commit: 9702091d5f77c2d1dfe1f8ca254c0910738da359
 
   - name: libp11
-    buildsystem: autotools
     config-opts:
       - --with-enginesdir=${FLATPAK_DEST}/lib/engines-3/
       - --with-modulesdir=${FLATPAK_DEST}/lib/ossl-modules/
@@ -82,8 +81,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
-        sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
+        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.16/libp11-0.4.16.tar.gz
+        sha256: 97777640492fa9e5831497e5892e291dfbf39a7b119d9cb6abb3ec8c56d17553
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.0
-        commit: cbe48da7dc88d84606fb7159534350d199162f94
+        tag: v3.16.1
+        commit: d78359d1bc46600d850b01b234dcd7c6e983ff43
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -23,6 +23,7 @@ finish-args:
   - --own-name=com.nextcloudgmbh.Nextcloud
   - --talk-name=org.kde.kwalletd5
   - --env=TMPDIR=/var/tmp
+  - --env=QT_QPA_PLATFORMTHEME=kde
 
 cleanup:
   - /share/icons/hicolor/1024x1024

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.14.2
-        commit: 4eec4f3d30d68deaf0a7ee5e866d7647d0c80e3c
+        tag: v3.14.3
+        commit: 3cdc27b7e809cb068f7ddf06a31cd7a32020c128
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.17.0
-        commit: 55f04ef44f1706551f648094a832eb3bac04758f
+        tag: v3.17.1
+        commit: d5403feb60fd3bb9e2898d0d54aae01fa75509bc
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.3
-        commit: a3b9b08db9fe11e8b9522d28813ef95832548d88
+        tag: v3.16.4
+        commit: 0febbee77be35f9a17f591b22767e1500192d14f
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -80,6 +80,8 @@ modules:
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
       - -DBUILD_UPDATER=OFF
+      - -DPLUGIN_INSTALL_DIR=/app/lib/plugins
+      - -DPLUGINDIR=/app/lib/plugins
     cleanup:
       - /include
     post-install:

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -81,14 +81,12 @@ modules:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
         sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
-    make-install-args:
-      - DESTDIR=${FLATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja
     build-options:
       env:
-        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.17.2
-        commit: d15dca2ae3b0d6e71c799fb4a439a71bc91cd4c4
+        tag: v3.17.3
+        commit: 392da9a259781ab229d0b101464516c40c0e1ee6
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.9'
+base-version: '6.10'
 
 command: nextcloud
 

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -1,11 +1,11 @@
 app-id: com.nextcloud.desktopclient.nextcloud
 
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.7'
+base-version: '6.8'
 
 command: nextcloud
 

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.6
-        commit: 957b27497fbe7ca14c26a45e6967a097b96a0add
+        tag: v3.17.0
+        commit: 55f04ef44f1706551f648094a832eb3bac04758f
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -73,6 +73,17 @@ modules:
         tag: 0.3.6
         commit: 9702091d5f77c2d1dfe1f8ca254c0910738da359
 
+  - name: libp11
+    buildsystem: autotools
+    cleanup:
+      - /include
+    sources:
+      - type: archive
+        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.12/libp11-0.4.12.tar.gz
+        sha256: 1e1a2533b3fcc45fde4da64c9c00261b1047f14c3f911377ebd1b147b3321cfd
+    make-install-args:
+      - DESTDIR=${FLATPAK_DEST}
+
   - name: nextcloud-client
     buildsystem: cmake-ninja
     config-opts:

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -75,8 +75,6 @@ modules:
 
   - name: libp11
     buildsystem: autotools
-    config-opts:
-      - --prefix=/
     cleanup:
       - /include
     sources:

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -34,7 +34,7 @@ modules:
   - shared-modules/libsecret/libsecret.json
 
   - name: qtkeychain
-    buildsystem: cmake
+    buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_INSTALL_LIBDIR=lib
       - -DBUILD_TRANSLATIONS=NO
@@ -74,7 +74,7 @@ modules:
         commit: 141fb072cc5080a8c547b8a536a45c0f9cf65691
 
   - name: nextcloud-client
-    buildsystem: cmake
+    buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -12,7 +12,7 @@ command: nextcloud
 finish-args:
   - --device=dri
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=network
   - --share=ipc
   - --filesystem=host:rw

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -81,8 +81,6 @@ modules:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.14/libp11-0.4.14.tar.gz
         sha256: 652ae2ac0732ec1eb998e8a99409eec6a00d5b47717f973b6bfb6c50f7a0ac60
-    config-opts:
-      - --prefix=${FLATPAK_DEST}
 
   - name: nextcloud-client
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -88,7 +88,7 @@ modules:
     buildsystem: cmake-ninja
     build-options:
       env:
-        PKG_CONFIG_PATH: /app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.14.1
-        commit: 8b92fc33a289bf4fc7bc7cdd68d25a9ed1ae1782
+        tag: v3.14.2
+        commit: 4eec4f3d30d68deaf0a7ee5e866d7647d0c80e3c
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.1
-        commit: d78359d1bc46600d850b01b234dcd7c6e983ff43
+        tag: v3.16.2
+        commit: d004c948bbdd5a0547e44e33e02899bf2f3046a9
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.14.3
-        commit: 3cdc27b7e809cb068f7ddf06a31cd7a32020c128
+        tag: v3.15.0
+        commit: eb04ac92122be40ce0fdc82557a26ccbd8684474
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.17.1
-        commit: d5403feb60fd3bb9e2898d0d54aae01fa75509bc
+        tag: v3.17.2
+        commit: d15dca2ae3b0d6e71c799fb4a439a71bc91cd4c4
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -89,8 +89,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.12.1
-        commit: 3191603be5301cce20b064673d68bafa14ef647b
+        tag: v3.12.2
+        commit: b846740b0207f9f0934402e19c6a1f3921cf6d11
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -22,6 +22,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=com.nextcloudgmbh.Nextcloud
   - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
   - --env=TMPDIR=/var/tmp
 
 cleanup:

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -104,8 +104,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.16.2
-        commit: d004c948bbdd5a0547e44e33e02899bf2f3046a9
+        tag: v3.16.3
+        commit: a3b9b08db9fe11e8b9522d28813ef95832548d88
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -79,6 +79,7 @@ modules:
       - -DNO_SHIBBOLETH=1
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
+      - -DBUILD_UPDATER=OFF
     cleanup:
       - /include
     post-install:

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -86,8 +86,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.10.1
-        commit: adf8fc77b37e692698cf089a8d0a4988d48545ab
+        tag: v3.10.2
+        commit: 2e210db26bdba37e494591fe653f588c12ee26cf
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.15.1
-        commit: 5c68160f10b5aa0954e1190cc0b2bdca628f7f34
+        tag: v3.15.2
+        commit: 6e4ffdfb460c41e8f671e54b6705b3c9a45efcca
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -89,8 +89,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.12.0
-        commit: 1c1e752c4d2a49b3f0c34eba35f88157d5e55a20
+        tag: v3.12.1
+        commit: 3191603be5301cce20b064673d68bafa14ef647b
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.15.2
-        commit: 6e4ffdfb460c41e8f671e54b6705b3c9a45efcca
+        tag: v3.15.3
+        commit: a595d5bcb6f13f4ea4080b694682a5ae43e2f769
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v4.0.3
-        commit: 98ddb954f8b6d4fac611b74e8ff2cf80c0939a28
+        tag: v4.0.4
+        commit: fbff567a0f3bc059c88a7cddcdfb7adf5078da25
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -45,8 +45,8 @@ modules:
       - /lib/cmake
     sources:
       - type: archive
-        url: https://github.com/frankosterfeld/qtkeychain/archive/0.14.3.tar.gz
-        sha256: a22c708f351431d8736a0ac5c562414f2b7bb919a6292cbca1ff7ac0849cb0a7
+        url: https://github.com/frankosterfeld/qtkeychain/archive/0.15.0.tar.gz
+        sha256: f4254dc8f0933b06d90672d683eab08ef770acd8336e44dfa030ce041dc2ca22
         x-checker-data:
           type: anitya
           url-template: https://github.com/frankosterfeld/qtkeychain/archive/$version.tar.gz
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.15.2
-        commit: 6e4ffdfb460c41e8f671e54b6705b3c9a45efcca
+        tag: v3.15.3
+        commit: a595d5bcb6f13f4ea4080b694682a5ae43e2f769
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -86,8 +86,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.10.2
-        commit: 2e210db26bdba37e494591fe653f588c12ee26cf
+        tag: v3.11.0
+        commit: f91ae00cfa5113e0991d7c476460c8f55a80990f
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v4.0.1
-        commit: e81c242e131f207f0c18081004453a01af5bd51e
+        tag: v4.0.2
+        commit: 4d0e5a3a97204302008c6b15b042c2e4ac6c1a04
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -86,6 +86,9 @@ modules:
 
   - name: nextcloud-client
     buildsystem: cmake-ninja
+    build-options:
+      env:
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,8 +92,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v3.15.0
-        commit: eb04ac92122be40ce0fdc82557a26ccbd8684474
+        tag: v3.15.1
+        commit: 5c68160f10b5aa0954e1190cc0b2bdca628f7f34
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -107,8 +107,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v4.0.2
-        commit: 4d0e5a3a97204302008c6b15b042c2e4ac6c1a04
+        tag: v4.0.3
+        commit: 98ddb954f8b6d4fac611b74e8ff2cf80c0939a28
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -106,8 +106,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v4.0.4
-        commit: fbff567a0f3bc059c88a7cddcdfb7adf5078da25
+        tag: v4.0.5
+        commit: 0bcb41dd463a94f9ee515e84eb490d41c8097a57
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -73,8 +73,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/World/libcloudproviders.git
-        tag: 0.3.6
-        commit: 9702091d5f77c2d1dfe1f8ca254c0910738da359
+        tag: 0.4.0
+        commit: 510f0eee666e4f99e8b11eb55945347db371b47c
         x-checker-data:
           type: anitya
           tag-template: $version
@@ -89,8 +89,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.16/libp11-0.4.16.tar.gz
-        sha256: 97777640492fa9e5831497e5892e291dfbf39a7b119d9cb6abb3ec8c56d17553
+        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.17/libp11-0.4.17.tar.gz
+        sha256: bbd86cdadd0493304be85c01a8604988c8f6c3fff8a902aa3f542a924699c080
         x-checker-data:
           type: anitya
           url-template: https://github.com/OpenSC/libp11/releases/download/libp11-$version/libp11-$version.tar.gz

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -92,7 +92,6 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_LIBDIR=lib
-      - -DNO_SHIBBOLETH=1
       - -DBUILD_SHELL_INTEGRATION_DOLPHIN=0
       - -DBUILD_SHELL_INTEGRATION_NAUTILUS=0
       - -DBUILD_UPDATER=OFF

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -130,14 +130,14 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v4.0.6
-        commit: 847472c1e712da60c441d35de5a1070edebe9251
+        tag: v33.0.0-rc1
+        commit: f2cb73873adfd94654d1272eb9a38574df49bcb6
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/nextcloud/desktop/releases/latest
-          tag-query: .tag_name
+          url: https://api.github.com/repos/nextcloud/desktop/releases
+          tag-query: map(select(.prerelease)) | first | .tag_name
           version-query: $tag | sub("^[vV]"; "")
-          timestamp-query: .published_at
+          timestamp-query: map(select(.prerelease)) | first | .published_at
       - type: patch
         path: dbus-service-path.patch
       - type: patch

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -75,6 +75,11 @@ modules:
         url: https://gitlab.gnome.org/World/libcloudproviders.git
         tag: 0.3.6
         commit: 9702091d5f77c2d1dfe1f8ca254c0910738da359
+        x-checker-data:
+          type: anitya
+          tag-template: $version
+          stable-only: true
+          project-id: 21207
 
   - name: libp11
     config-opts:
@@ -86,6 +91,11 @@ modules:
       - type: archive
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.16/libp11-0.4.16.tar.gz
         sha256: 97777640492fa9e5831497e5892e291dfbf39a7b119d9cb6abb3ec8c56d17553
+        x-checker-data:
+          type: anitya
+          url-template: https://github.com/OpenSC/libp11/releases/download/libp11-$version/libp11-$version.tar.gz
+          stable-only: true
+          project-id: 1699
 
   - name: KDSingleApplication
     buildsystem: cmake-ninja

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -106,8 +106,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v4.0.5
-        commit: 0bcb41dd463a94f9ee515e84eb490d41c8097a57
+        tag: v4.0.6
+        commit: 847472c1e712da60c441d35de5a1070edebe9251
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases/latest

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -87,6 +87,21 @@ modules:
         url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.16/libp11-0.4.16.tar.gz
         sha256: 97777640492fa9e5831497e5892e291dfbf39a7b119d9cb6abb3ec8c56d17553
 
+  - name: KDSingleApplication
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DKDSingleApplication_EXAMPLES=OFF
+    sources:
+      - type: archive
+        url: https://github.com/KDAB/KDSingleApplication/releases/download/v1.2.0/kdsingleapplication-1.2.0.tar.gz
+        sha256: ff4ae6a4620beed1cdb3e6a9b78a17d7d1dae7139c3d4746d4856b7547d42c38
+        x-checker-data:
+          type: anitya
+          project-id: 370439
+          url-template: https://github.com/KDAB/KDSingleApplication/releases/download/v$version/kdsingleapplication-$version.tar.gz
+
   - name: nextcloud-client
     buildsystem: cmake-ninja
     config-opts:

--- a/dbus-service-path.patch
+++ b/dbus-service-path.patch
@@ -4,8 +4,13 @@ index 2e7349ef7..f7a161c05 100644
 +++ b/shell_integration/libcloudproviders/CMakeLists.txt
 @@ -1,5 +1,5 @@
  macro(dbus_add_activation_service _sources)
+ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28.0") 
+-    pkg_get_variable(_install_dir dbus-1 session_bus_services_dir DEFINE_VARIABLES datadir=${CMAKE_INSTALL_DATADIR})
++    set(_install_dir "${CMAKE_INSTALL_PREFIX}/share/dbus-1/services")
+ else()
 -    pkg_get_variable(_install_dir dbus-1 session_bus_services_dir)
 +    set(_install_dir "${CMAKE_INSTALL_PREFIX}/share/dbus-1/services")
+ endif()
      foreach (_i ${_sources})
          get_filename_component(_service_file ${_i} ABSOLUTE)
          string(REGEX REPLACE "\\.service.*$" ".service" _output_file ${_i})

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
This should allow us to provide rc*-prereleases to the beta branch.  Also updated the reference to `33.0.0-rc1`.
See also https://docs.flathub.org/docs/for-app-authors/maintenance#the-repository