### PR TITLE
[beta] Update libp11 to 0.4.18 and nextcloud-client to 33.0.0-rc2

### DIFF
--- a/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -28,8 +28,11 @@ Any file you add, modify or delete in the synced folders on your desktop or lapt
   <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
   <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
   <releases>
-    <release version="33.0.0-rc1" date="2026-02-18">
+    <release version="33.0.0-rc2" date="2026-02-27">
       <description></description>
+    </release>
+    <release version="33.0.0-rc1" date="2026-02-18">
+      <description/>
     </release>
     <release version="4.0.6" date="2026-01-22">
       <description/>

--- a/com.nextcloud.desktopclient.nextcloud.yml
+++ b/com.nextcloud.desktopclient.nextcloud.yml
@@ -89,8 +89,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.17/libp11-0.4.17.tar.gz
-        sha256: bbd86cdadd0493304be85c01a8604988c8f6c3fff8a902aa3f542a924699c080
+        url: https://github.com/OpenSC/libp11/releases/download/libp11-0.4.18/libp11-0.4.18.tar.gz
+        sha256: 9292de67ca73aba1deacf577c9086b595765f36ef47712cfeb49fa31f6e772fb
         x-checker-data:
           type: anitya
           url-template: https://github.com/OpenSC/libp11/releases/download/libp11-$version/libp11-$version.tar.gz
@@ -130,8 +130,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nextcloud/desktop.git
-        tag: v33.0.0-rc1
-        commit: f2cb73873adfd94654d1272eb9a38574df49bcb6
+        tag: v33.0.0-rc2
+        commit: 85682618318a28eb6f216e764a7f4000a3964d13
         x-checker-data:
           type: json
           url: https://api.github.com/repos/nextcloud/desktop/releases


### PR DESCRIPTION
libp11: Update libp11-0.4.17.tar.gz to 0.4.18
nextcloud-client: Update desktop.git to 33.0.0-rc2